### PR TITLE
Fix bug where announcements csv was empty in mail

### DIFF
--- a/App/functions/index.js
+++ b/App/functions/index.js
@@ -685,7 +685,7 @@ async function CourseMailer(list, passCode, email, announcements, qc, fc) {
   const studentString = `${studentheaderString}${studentrowString}`;
   const announcementheaderString = 'Announcement Date, Announcement Heading, Announcement Description\n';
   let announcementrowString = ` , , \n`;
-  if (!announcements === "-1") { announcementrowString = await announcements.map((announcement, i) => `${announcement.date},${announcement.heading},${announcement.description}\n`).join(''); }
+  if (announcements !== "-1") { announcementrowString = await announcements.map((announcement, i) => `${announcement.date},${announcement.heading},${announcement.description}\n`).join(''); }
   const announcementString = `${announcementheaderString}${announcementrowString}`;
 
   try {


### PR DESCRIPTION
This PR fixes #60 .

The empty announcements csv was due to a faulty if condition [here](https://github.com/Active-Learning-and-Teaching/ALT/blob/78be8c3872d96701c2136d24ae1d54dfdfaf961b/App/functions/index.js#L688)