### PR TITLE
Exact Matching fixed, no uppecase matching

### DIFF
--- a/App/Components/Quiz/QuizResultGraph.js
+++ b/App/Components/Quiz/QuizResultGraph.js
@@ -152,7 +152,7 @@ export default class QuizResultGraph extends Component {
                 }
 
                 {this.props.correctAnswer!=="*"
-                    ? <Text style={styles.ca}> Correct Answer  : {this.props.correctAnswer.trim().toUpperCase()}</Text>
+                    ? <Text style={styles.ca}> Correct Answer  : {this.props.correctAnswer.trim() }</Text>      // trim.toupper
                     :<View/>
                 }
                 </View>

--- a/App/Databases/QuizResponses.js
+++ b/App/Databases/QuizResponses.js
@@ -191,7 +191,7 @@ class QuizResponses {
                     const temp2 = moment(endTime, "DD/MM/YYYY HH:mm:ss")
 
                     if (temp1<=temp2 && temp1>=temp){
-                        let answer = keys["answer"].trim().toUpperCase().replace(/,/g,"")
+                        let answer = keys["answer"].trim().replace(/,/g,"")       // trim().toUppercase().
                         console.log(answer)
                         if(answer in dict){
                             dict[answer]+=1

--- a/App/functions/index.js
+++ b/App/functions/index.js
@@ -362,10 +362,11 @@ function autoGrader(studentAnswer,correctAnswer,type){
           return 0;
   }
   else{
-      studentAnswer = studentAnswer.trim().toUpperCase().replace(/,/g,"")
-      correctAnswer = correctAnswer.trim().toUpperCase().replace(/,/g,"")
+      studentAnswer = studentAnswer.trim().replace(/,/g,"")               // trum.toupper
+      correctAnswer = correctAnswer.trim().replace(/,/g,"")               // trim.toupper
                   
       if(studentAnswer===correctAnswer)
+
           return 1;
       else if(!studentAnswer.search(correctAnswer)===-1)
           return 1;
@@ -398,7 +399,7 @@ async function getQuizResponse(passCode,startTime,endTime,type){
 
                   if (type==="mcq"){list[keys["answer"]] += 1}
                   else{
-                  let answer = keys["answer"].trim().toUpperCase().replace(/,/g,"")
+                  let answer = keys["answer"].trim().replace(/,/g,"")       // toupper
                   if(answer in dict){dict[answer]+=1}
                   else{dict[answer] = 1}
                   }
@@ -412,7 +413,7 @@ async function getQuizResponse(passCode,startTime,endTime,type){
 }
 async function QuizResponseMailer(list,answer,type,passCode,quizNumber,startTime,endTime,email){
   
-  const correctAnswer = answer === "*" ? 'N/A' : answer.trim().toUpperCase().replace(/,/g,"");
+  const correctAnswer = answer === "*" ? 'N/A' : answer.trim().replace(/,/g,"");  // toupper
   max = answer==="*"?'N/A':1
   const date = startTime.replace(/\//g,"-").split(" ")[0]
   const fileName = passCode+"_"+date+"_"+"Quiz-"+quizNumber
@@ -494,7 +495,7 @@ async function getAllStudentsforMail(passCode, startTime, endTime){
               const temp2 = moment(endTime, "DD/MM/YYYY HH:mm:ss")
 
               if (temp1<=temp2 && temp1>=temp){
-                  let answer = keys['answer'].trim().toUpperCase()
+                  let answer = keys['answer'].trim()  // toupper
                   let email = keys['userName']
                   let ID = keys['userID']
                   let name = keys['name']===undefined? "N/A": keys["name"]


### PR DESCRIPTION
This pull request is regarding the exact matching of text quizzes. Earlier, the evaluation was case-insensitive; all the answers were converted to uppercase. Now it has been made case-sensitive. All the answers will be exactly as they are written. 

I have for you here the test run for reference. 
![alt-exactmatching](https://user-images.githubusercontent.com/83447461/221418861-2bc08a39-1cf1-40b7-aade-03729fafd078.png)

These changes were made after feedback from Dr Pankaj Jalote.